### PR TITLE
replace terminix with tilix

### DIFF
--- a/_manual/badges.md
+++ b/_manual/badges.md
@@ -3,7 +3,7 @@ title: Badges
 id: badges
 layout: default
 ---
-*Note that badges requires that the GTK VTE widget be built with a terminix specific [patch](https://github.com/gnunn1/terminix/blob/master/experimental/vte/alternate-screen.patch), otherwise badges are disabled. Arch users can access this functionality by installing the [vte3-terminix-git](https://aur.archlinux.org/packages/vte3-terminix-git) package.*
+*Note that badges requires that the GTK VTE widget be built with a tilix specific [patch](https://github.com/gnunn1/tilix/blob/master/experimental/vte/alternate-screen.patch), otherwise badges are disabled. Arch users can access this functionality by installing the [vte3-terminix-git](https://aur.archlinux.org/packages/vte3-terminix-git) package.*
 
 ![]({{site.baseurl}}/assets/images/manual/badges.png)
 

--- a/_manual/cliactions.md
+++ b/_manual/cliactions.md
@@ -5,11 +5,11 @@ layout: default
 ---
 #### Introduction
 
-Tilix supports the use of command line actions to have the running instance execute an action that you would typically do through the user interface. The use case for this functionality is to be able run a script within terminix that causes it to perform certain commands. For example, to have Tilix run the command ```yaourt -Syua``` in a new terminal that is split right, the following command can be used:
+Tilix supports the use of command line actions to have the running instance execute an action that you would typically do through the user interface. The use case for this functionality is to be able run a script within tilix that causes it to perform certain commands. For example, to have Tilix run the command ```yaourt -Syua``` in a new terminal that is split right, the following command can be used:
 
 
 {% highlight bash %}
-terminix -a session-add-right -x "yaourt -Syua"
+tilix -a session-add-right -x "yaourt -Syua"
 {% endhighlight %}
 
 The -a, or --action, command line switch is what is used to specify the action to be executed. Any action executed is always done relative to the terminal where the command was executed. Any command line parameters that are specified as part of the command get passed to the new terminal. This allows you to do a variety of things such as use a different profile, specify the working directory or as per the example above, execute a command.

--- a/_manual/profileswitch.md
+++ b/_manual/profileswitch.md
@@ -23,10 +23,10 @@ Note that switching profiles based on username requires the use of a trigger to 
 
 To enable profile changes when using SSH to connect to remote systems, the remote system must be configured to include an additional script or an appropriate trigger configured. 
 
-If you opt for the script, first scp the script ```/usr/share/terminix/scripts/terminix_int.sh``` from your local system where terminix is installed to the remote system. You will then need to source this script on the remote system, the easiest way to do this is to modify the .bashrc of the user you use to connect to include the script. For example, add the following to .bashrc:
+If you opt for the script, first scp the script ```/usr/share/tilix/scripts/tilix_int.sh``` from your local system where tilix is installed to the remote system. You will then need to source this script on the remote system, the easiest way to do this is to modify the .bashrc of the user you use to connect to include the script. For example, add the following to .bashrc:
 
 {% highlight bash %}
-. ./terminix_int.sh
+. ./tilix_int.sh
 {% endhighlight %}
 
 if you switch users on the remote system, you may need to source the script somewhere so it is available to all users.

--- a/_manual/quake.md
+++ b/_manual/quake.md
@@ -10,7 +10,7 @@ Tilix supports running in a _Quake_-style mode where it appears at the top of th
 When you register the hot key, simply bind it to the following command:
 
 {% highlight bash %}
-terminix --quake
+tilix --quake
 {% endhighlight %}
 
 When Tilix is run with the `--quake` switch, it will check if a quake style window is already running and if so simply toggle the window's visibility. If no quake style window has been created, then Tilix will create one and display it.

--- a/_manual/themes.md
+++ b/_manual/themes.md
@@ -43,6 +43,6 @@ Tilix supports themes for configuring the color scheme of the terminal, each the
 }
 {% endhighlight %}
 
-Themes are loaded from one of two places by Tilix. The first is ```/usr/share/terminix/schemes```, these are the themes that are shipped with Tilix. The second place that Tilix looks for theme files is in the user home directory, specifically ```~/.config/terminix/schemes```. Users can place any custom themes they want to use here.
+Themes are loaded from one of two places by Tilix. The first is ```/usr/share/tilix/schemes```, these are the themes that are shipped with Tilix. The second place that Tilix looks for theme files is in the user home directory, specifically ```~/.config/tilix/schemes```. Users can place any custom themes they want to use here.
 
 While Tilix only includes a small number of themes, additional themes can be easily downloaded and installed. The GitHub repository [Tilix-Themes](https://github.com/storm119/Tilix-Themes) has a wide variety of pre-built themes to choose from.

--- a/_manual/vteconfig.md
+++ b/_manual/vteconfig.md
@@ -26,7 +26,7 @@ Fortunately fixing this issue is quite easy, you can do either of the two option
 
 Update ```~.bashrc``` (or ```~.zshrc``` if you are using zsh) to execute vte.sh directly, this involves adding the following line at the end of the file.
 {% highlight bash %}
-if [ $TERMINIX_ID ] || [ $VTE_VERSION ]; then
+if [ $TILIX_ID ] || [ $VTE_VERSION ]; then
         source /etc/profile.d/vte.sh
 fi
 {% endhighlight %}
@@ -53,4 +53,4 @@ PROMPT_COMMAND=`custom_prompt`
 
 Enable the option in your Tilix Profile (under Preferences) to use a login shell, the screenshot below shows the option that needs to be checked.
 
-![Profile - Command](http://gexperts.com/img/terminix/terminix_login_shell.png)
+![Profile - Command](http://gexperts.com/img/tilix/tilix_login_shell.png)

--- a/_manual/vteconfig.md
+++ b/_manual/vteconfig.md
@@ -53,4 +53,4 @@ PROMPT_COMMAND=`custom_prompt`
 
 Enable the option in your Tilix Profile (under Preferences) to use a login shell, the screenshot below shows the option that needs to be checked.
 
-![Profile - Command](http://gexperts.com/img/tilix/tilix_login_shell.png)
+![Profile - Command](https://gnunn1.github.io/tilix-web/assets/images/manual/tilix_login_shell.png)

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -2,7 +2,7 @@
         $('.scroll a').bind('click', function (event) {
             var $anchor = $(this).attr("href");
             $anchor = $anchor.split("/").join("");
-            $anchor = $anchor.replace("terminix-web","");
+            $anchor = $anchor.replace("tilix-web","");
             $anchor = $anchor.replace("faq","");
             $anchor = $anchor.replace("manual","");
             if ($anchor.length) {

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@ layout: default
             <i class="fa fa-globe fa-5x" aria-hidden="true"></i>
         </div>
         <div>
-            Tilix welcomes contributions and encourages participation from the community, for developers please visit the <a href="https://github.com/gnunn1/tilix">Tilix Github Development</a> site to contribute. For translators, Tilix is localized using Weblate, please visit the Weblate hosted <a href="https://hosted.weblate.org/projects/terminix/translations">Tilix translations site</a> in order to assist with translations, please do not submit direct pull requests to the repository for translations.
+            Tilix welcomes contributions and encourages participation from the community, for developers please visit the <a href="https://github.com/gnunn1/tilix">Tilix Github Development</a> site to contribute. For translators, Tilix is localized using Weblate, please visit the Weblate hosted <a href="https://hosted.weblate.org/projects/tilix/translations">Tilix translations site</a> in order to assist with translations, please do not submit direct pull requests to the repository for translations.
         </div>
         <br>
         <br class="clear-fix">

--- a/manual.html
+++ b/manual.html
@@ -1,10 +1,10 @@
 ---
 permalink: /manual/
-title: Terminix&colon; Documentation
+title: Tilix&colon; Documentation
 layout: default
 ---
 <h1>Documentation</h1>
-<p>Welcome to the Terminix documentation, here is where you will learn to use all of the features in Terminix and make your experience as fun and productive as possible. Click on a link below to read more about a specific feature and how to get started using it.</p>
+<p>Welcome to the Tilix documentation, here is where you will learn to use all of the features in Tilix and make your experience as fun and productive as possible. Click on a link below to read more about a specific feature and how to get started using it.</p>
 {% for manual in site.manual %}
     <div id="{{manual.id}}">
     	<ul>

--- a/news/index.html
+++ b/news/index.html
@@ -1,5 +1,5 @@
 ---
-title: Terminix&colon; News
+title: Tilix&colon; News
 layout: default
 ---
  <div class="section">


### PR DESCRIPTION
Few fixes with just replacing terminix with tilix.
The only terminix stuff that are still on the website are : old news, old packages (need info from package maintaners) and the iirc room
