### PR TITLE
Added information on where to get tilix in Fedora

### DIFF
--- a/_packages/fedora.md
+++ b/_packages/fedora.md
@@ -2,5 +2,5 @@
 title: Fedora
 id: fedora
 ---
-For Fedora 24/25, Terminix is available in a [COPR Repository](https://copr.fedorainfracloud.org/coprs/heikoada/terminix).
-For Fedora 26 and newer, Terminix is available in the default repository.
+For Fedora 24/25, Tiliw is available in a [COPR Repository](https://copr.fedorainfracloud.org/coprs/heikoada/terminix).
+For Fedora 26 and newer, Tilix is available in the default repository.

--- a/_packages/fedora.md
+++ b/_packages/fedora.md
@@ -2,4 +2,5 @@
 title: Fedora
 id: fedora
 ---
-For Fedora, Terminix is available in a [COPR Repository](https://copr.fedorainfracloud.org/coprs/heikoada/terminix).
+For Fedora 24/25, Terminix is available in a [COPR Repository](https://copr.fedorainfracloud.org/coprs/heikoada/terminix).
+For Fedora 26 and newer, Terminix is available in the default repository.


### PR DESCRIPTION
In fedora 26, the tilix package is added in the default repositories.

I added the and older so you wouldn't have to change this in the future, since I have no reason to believe it won't be in older fedora releases with so much community support behind it.