### PR TITLE
Updated packages URL

### DIFF
--- a/_manual/badges.md
+++ b/_manual/badges.md
@@ -4,7 +4,7 @@ id: badges
 layout: manual
 description:  Badges are displayed in the background of a terminal and can display a variety of information about the terminal session. 
 ---
-*Note that badges requires that the GTK VTE widget be built with a tilix specific [patch](https://github.com/gnunn1/tilix/blob/master/experimental/vte/alternate-screen.patch), otherwise badges are disabled. Arch users can access this functionality by installing the [vte3-terminix-git](https://aur.archlinux.org/packages/vte3-terminix-git) package.*
+*Note that badges requires that the GTK VTE widget be built with a tilix specific [patch](https://github.com/gnunn1/tilix/blob/master/experimental/vte/alternate-screen.patch), otherwise badges are disabled. Arch users can access this functionality by installing the [vte3-tilix](https://aur.archlinux.org/packages/vte3-tilix) package.*
 
 ![]({{site.baseurl}}/assets/images/manual/badges.png)
 

--- a/_packages/opensuse.md
+++ b/_packages/opensuse.md
@@ -2,4 +2,4 @@
 title: OpenSUSE
 id: opensuse
 ---
-Terminix packages for OpenSUSE can be found by performing a [Package Search](https://software.opensuse.org/package/terminix).
+Tilix packages for OpenSUSE can be found by performing a [Package Search](https://software.opensuse.org/package/tilix).

--- a/_packages/tanglu.md
+++ b/_packages/tanglu.md
@@ -1,5 +1,0 @@
----
-title: Tanglu
-id: tanglu
----
-Terminix is available as [Part of Tanglu 4](http://packages.tanglu.org/dasyatis/terminix).


### PR DESCRIPTION
Hi,
Here is a small PR with the following changes:

- updated packages url for ArchLinux and openSUSE
- removed tanglu.md as package does not appear to be in their repos anymore (both terminix and tilix cannot be found through their search engine).

Thank you