### PR TITLE
Getting Tilix: Set .tabs-content li margin 0

### DIFF
--- a/src/sass/modules/_tabs.scss
+++ b/src/sass/modules/_tabs.scss
@@ -72,6 +72,7 @@
     li {
       list-style-type: none;
       display: none;
+      margin: 0;
       padding: 10px 16px;
       text-align: justify;
       border: 1px solid #DADFE1;


### PR DESCRIPTION
In Chrome I had an issue with the margins of the 'Getting Tilix' tab contents.

See screenshot:

![image](https://user-images.githubusercontent.com/906457/31076512-0c35ec5c-a7ad-11e7-9b14-75cc396ce8ca.png)


This should fix it (NOT tested)