### PR TITLE
Update Arch Linux

### DIFF
--- a/_packages/arch.md
+++ b/_packages/arch.md
@@ -3,4 +3,6 @@ title: Archlinux
 _id: arch
 order: 3
 ---
-Tilix is available in Arch Linux via the Arch User Repository (AUR) as the [AUR Tilix Package](https://aur.archlinux.org/packages/tilix).
+Tilix is available in Arch Linux' [repository](https://www.archlinux.org/packages/community/x86_64/tilix/) and can be installed with:
+
+`pacman -S tilix`


### PR DESCRIPTION
Tilix is now maintained in the official repository.