### PR TITLE
Fix typo in ubuntu package's description

### DIFF
--- a/_packages/ubuntu.md
+++ b/_packages/ubuntu.md
@@ -4,6 +4,6 @@ _id: ubuntu
 order: 10
 ---
 
-Officiel Tilix packages are available for Ubuntu [artful](https://packages.ubuntu.com/artful/tilix) and [bionic](https://packages.ubuntu.com/bionic/tilix).
+Official Tilix packages are available for Ubuntu [artful](https://packages.ubuntu.com/artful/tilix) and [bionic](https://packages.ubuntu.com/bionic/tilix).
 
 For older versions, tilix is available thanks to the WebUpd8 team and their PPA: [WebUpd8](https://launchpad.net/~webupd8team/+archive/ubuntu/terminix).


### PR DESCRIPTION
_Officiel_ should be _Official_ in English.