### PR TITLE
Update information on Fedora

### DIFF
--- a/_packages/fedora.md
+++ b/_packages/fedora.md
@@ -3,5 +3,6 @@ title: Fedora
 _id: fedora
 order: 6
 ---
-For Fedora 24/25, Tilix is available in a [COPR Repository](https://copr.fedorainfracloud.org/coprs/heikoada/terminix).
-For Fedora 26 and newer, Tilix is available in the default repository.
+Tilix is available in the default repository and can be installed with:
+
+    sudo dnf install tilix


### PR DESCRIPTION
Fedora 26's support ended over a year ago (2018-05-01,
[one month after] the [Fedora 28 release]).
It's safe to say that "Tilix is available in the default repository".

[one month after]: https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle#Maintenance_Schedule
[Fedora 28 release]: https://fedoraproject.org/wiki/Releases/28/Schedule#Key_Milestones