### PR TITLE
Fix symlink cmd

### DIFF
--- a/_manual/vteconfig.md
+++ b/_manual/vteconfig.md
@@ -32,9 +32,9 @@ if [ $TILIX_ID ] || [ $VTE_VERSION ]; then
 fi
 {% endhighlight %}
 
-On Ubuntu (16.04 or 16.10), a symlink is probably missing. You can create it with: 
+On Ubuntu (16.04 and above), a symlink is probably missing. You can create it with: 
 {% highlight bash %}
-ln -s /etc/profile.d/vte-2.91.sh /etc/profile.d/vte.sh
+sudo ln -s /etc/profile.d/vte-2.91.sh /etc/profile.d/vte.sh
 {% endhighlight %}
 If you use a custom `PROMPT_COMMAND` instead of simply overriding `PS1` you also
 need to update your `PROMPT_COMMAND` to append working directory information.


### PR DESCRIPTION
The symlink is at least also missing on Ubuntu 20.04.