### PR TITLE
Update README.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Website for the Tilix project
 ```bash
 git clone https://github.com/gnunn1/tilix-web/
 ```
-2- Install `jekyll` and `jekyll-paginate`
+2- Install `jekyll`, `jekyll-paginate` and `kramdown-parser-gfm`
 ```bash
-gem install jekyll jekyll-paginate
+gem install jekyll jekyll-paginate kramdown-parser-gfm
 ```
 3- Go the cloned directory and run Jekyll server
 ```bash


### PR DESCRIPTION
The `kramdown-parser-gfm` gem is also required, causing an error if not
found:
```
  Dependency Error: Yikes! It looks like you don't have kramdown-parser-gfm or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. The full error message from Ruby is: 'cannot load such file -- kramdown-parser-gfm' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/!
  Conversion error: Jekyll::Converters::Markdown encountered an error while converting '_posts/2016-12-22-release-1-4-0.md':
                    kramdown-parser-gfm
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    kramdown-parser-gfm
```