### PR TITLE
Tilix is now available in FreeBSD

### DIFF
--- a/_packages/freebsd.md
+++ b/_packages/freebsd.md
@@ -1,0 +1,10 @@
+---
+title: FreeBSD
+_id: freebsd
+order: 7
+---
+Tilix is available as a [FreeBSD port](https://www.freshports.org/x11/tilix/) and a package can be installed with:
+
+```
+pkg install tilix
+```


### PR DESCRIPTION
Add link and instructions for running Tilix on FreeBSD.