### PR TITLE
Generalize Ubuntu hint in vteconfig.md

### DIFF
--- a/_manual/vteconfig.md
+++ b/_manual/vteconfig.md
@@ -32,7 +32,7 @@ if [ $TILIX_ID ] || [ $VTE_VERSION ]; then
 fi
 {% endhighlight %}
 
-On Ubuntu (16.04 or 16.10), a symlink is probably missing. You can create it with: 
+On Ubuntu, a symlink is probably missing. You can create it with: 
 {% highlight bash %}
 ln -s /etc/profile.d/vte-2.91.sh /etc/profile.d/vte.sh
 {% endhighlight %}


### PR DESCRIPTION
I have a fresh Ubuntu 24.04 system and the symlink is missing there, too. Therefore I removed the hint that this was needed for Ubuntu 16.04/16.10 only.