### PR TITLE
Document Ubuntu 25.04 default terminal

### DIFF
--- a/_faqs/general.md
+++ b/_faqs/general.md
@@ -20,6 +20,12 @@ sudo update-alternatives --config x-terminal-emulator
 
 And then pick Tilix from menu.
 
+For Ubuntu 25.04 onwards, run following command:
+
+```
+echo "com.gexperts.Tilix.desktop" > ~/.config/ubuntu-xdg-terminals.list
+```
+
 ##### How can I disable DBus Activation?
 
 Tilix has DBus activation enabled in the launcher. While for the vast majority of users this does not cause any issues, there have been a few edge cases found in rare situations such as the one identified [here](https://github.com/gnunn1/tilix/issues/870). If you are having this or an issue where the behavior of Tilix is subtlely different then Gnome Terminal, you can try to disable DBus Activation.


### PR DESCRIPTION
Ubuntu 25.04 changed the way to setup a default terminal: https://documentation.ubuntu.com/desktop/en/latest/how-to/change-the-default-terminal/#on-ubuntu-25-04-and-later

For tilix, following command worked for me:

```bash
echo "com.gexperts.Tilix.desktop" > ~/.config/ubuntu-xdg-terminals.list
```